### PR TITLE
Deprecate `MMatrix` & `MArray` in `Lattice`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,9 @@ authors = ["singularitti <singularitti@outlook.com> and contributors"]
 version = "0.1.0"
 
 [deps]
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-StaticArrays = "1"
 julia = "1"
 
 [extras]

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,17 +1,12 @@
-using StaticArrays: MMatrix, MArray
-
 export Lattice, Evolution
 
-struct Lattice{S1,S2,T} <: AbstractMatrix{T}
-    spins::MMatrix{S1,S2,T}
+struct Lattice{T} <: AbstractMatrix{T}
+    spins::Matrix{T}
 end
-Lattice(spins::AbstractMatrix) = Lattice{size(spins, 1),size(spins, 2),eltype(spins)}(spins)
 
-struct Evolution{S1,S2,S3,T} <: AbstractArray{T,3}
-    history::MArray{Tuple{S1,S2,S3},T,3}
+struct Evolution{T} <: AbstractArray{T,3}
+    history::Array{T,3}
 end
-Evolution(history::AbstractArray) =
-    Evolution{size(history, 1),size(history, 2),size(history, 3),eltype(history)}(history)
 # See https://discourse.julialang.org/t/turn-vector-of-matrices-into-3d-array/69777/6
 Evolution(history::AbstractVector{<:Lattice}) =
     Evolution(reduce((x, y) -> cat(x, y; dims=3), history))


### PR DESCRIPTION
See https://discourse.julialang.org/t/creating-random-mmatrix-with-large-size-is-too-slow/90323