### PR TITLE
Use `flipspin` instead of `-` in `simulate!`

### DIFF
--- a/src/simulate!.jl
+++ b/src/simulate!.jl
@@ -18,3 +18,7 @@ function simulate!(lattice::Lattice, β, J, B, ::Basic)
     end
     return lattice
 end
+
+flipspin(lattice::Lattice, index::CartesianIndex) =
+    lattice[index] == lattice.states[1] ? lattice.states[2] : lattice.states[1]
+flipspin(lattice::Lattice, i, j) = flipspin(lattice, CartesianIndex(i, j))

--- a/src/simulate!.jl
+++ b/src/simulate!.jl
@@ -6,7 +6,7 @@ struct SwendsenWang <: Algorithm end
 
 function simulate!(lattice::Lattice, β, J, B, ::Basic)
     for index in eachindex(lattice)
-        trial_spin = -lattice[index]  # Trial move, no in-place update now!
+        trial_spin = flipspin(lattice, index)  # Trial move, no in-place update now!
         eᵢ_old = energy(lattice, index, J, B)
         eᵢ_new = energy(sum(neighborspins(lattice, index)), trial_spin, J, B)
         P = exp(-β * (eᵢ_new - eᵢ_old))

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,7 +2,14 @@ export Lattice, Evolution
 
 struct Lattice{T} <: AbstractMatrix{T}
     spins::Matrix{T}
+    states::NTuple{2,T}
+    function Lattice{T}(spins) where {T}
+        states = extrema(spins)
+        @assert all(spin in states for spin in spins)
+        return new(spins, states)
+    end
 end
+Lattice(spins::AbstractMatrix) = Lattice{eltype(spins)}(collect(spins))
 
 struct Evolution{T} <: AbstractArray{T,3}
     history::Array{T,3}


### PR DESCRIPTION
Add field `states` to `Lattice`, allowing only two states.
If we do not have this restriction, we could have states to be `0` and `1`, for example, and `simulate!` will generate a new state `-1` after running